### PR TITLE
Retry authentication forever

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -172,7 +172,8 @@ auth:
 	err := c.Authenticate()
 	if err != nil {
 		log.Errorf("[%s] %s", c.MACAddress, err)
-		return
+		time.Sleep(c.Config.AuthInterval)
+		goto auth
 	}
 
 	err = c.SendInventory()


### PR DESCRIPTION
If the auth call fails, just keep trying. This is to prevent missing
clients in the case that a auth request is not replied (server down).