### PR TITLE
Fix nil pointer dereference in response

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -319,7 +319,9 @@ func (c *Client) UpdateCheck() error {
 		}
 
 		// report the new artifact name
-		c.ArtifactName = response.Artifact.Name
+		if response.Artifact != nil {
+			c.ArtifactName = response.Artifact.Name
+		}
 		err = c.SendInventory()
 		if err != nil {
 			return err

--- a/client/client.go
+++ b/client/client.go
@@ -313,7 +313,7 @@ func (c *Client) UpdateCheck() error {
 			return err
 		}
 
-		err = c.Deployment(response.ID, response.Artifact)
+		err = c.Deployment(response.ID)
 		if err != nil {
 			return err
 		}
@@ -328,7 +328,7 @@ func (c *Client) UpdateCheck() error {
 	return nil
 }
 
-func (c *Client) Deployment(deploymentID string, artifact *model.DeploymentNextArtifact) error {
+func (c *Client) Deployment(deploymentID string) error {
 	statusURL := strings.Replace(urlDeploymentsStatus, "{id}", deploymentID, 1)
 
 	statuses := []string{


### PR DESCRIPTION
It seems like the server could send a 200 OK response where the artifact
object is not present. It does not seem correct, but in any case let's
do defensive programming in our side.